### PR TITLE
Fixes validations for Bootstrap v4 PR

### DIFF
--- a/app/components/create-options-text.js
+++ b/app/components/create-options-text.js
@@ -1,9 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { observer, computed, get } from '@ember/object';
-import { run, next } from '@ember/runloop';
-import BsFormElement from 'ember-bootstrap/components/bs-form/element';
-import { any } from 'ember-awesome-macros/array';
+import { observer } from '@ember/object';
 
 export default Component.extend({
   actions: {
@@ -15,75 +12,12 @@ export default Component.extend({
         position,
         fragment
       );
-
-      next(() => {
-        this.notifyPropertyChange('_childViews');
-      });
     },
     deleteOption(element) {
       let position = this.options.indexOf(element);
       this.options.removeAt(position);
-
-      next(() => {
-        this.notifyPropertyChange('_childViews');
-      });
     }
   },
-
-  anyElementHasFeedback: any('childFormElements.@each.hasFeedback', function(childFormElement) {
-    return get(childFormElement, 'hasFeedback');
-  }),
-
-  anyElementIsInvalid: any('childFormElements.@each.validation', function(childFormElement) {
-    return get(childFormElement, 'validation') === 'error';
-  }),
-
-  everyElementIsValid: computed('childFormElements.@each.validation', function() {
-    const anyElementIsInvalid = this.anyElementIsInvalid;
-    if (anyElementIsInvalid) {
-      return false;
-    }
-
-    // childFormElements contains button wrapper element which should not be taken into account here
-    const childFormElements = this.childFormElements.filterBy('hasValidator');
-    if (childFormElements) {
-      return childFormElements.every((childFormElement) => {
-        return childFormElement.get('hasFeedback') && childFormElement.get('validation') === 'success';
-      });
-    } else {
-      return false;
-    }
-  }),
-
-  childFormElements: computed('_childViews', function() {
-    return this.childViews.filter((childView) => {
-      return childView instanceof BsFormElement;
-    });
-  }),
-
-  // Can't use a computed property cause Ember Bootstrap seem to modify validation twice in a single render.
-  // Therefor we use the scheduleOnce trick.
-  // This is the same for {{create-options-datetime}} component.
-  labelValidationClass: 'label-has-no-validation',
-  updateLabelValidationClass: observer('anyElementHasFeedback', 'anyElementIsInvalid', 'everyElementIsValid', function() {
-    run.scheduleOnce('sync', () => {
-      let validationClass;
-
-      if (!this.anyElementHasFeedback) {
-        validationClass = 'label-has-no-validation';
-      } else if (this.anyElementIsInvalid) {
-        validationClass = 'label-has-error';
-      } else if (this.everyElementIsValid) {
-        validationClass = 'label-has-success';
-      } else {
-        validationClass = 'label-has-no-validation';
-      }
-
-      this.set('labelValidationClass', validationClass);
-    });
-  }).on('init'),
-
-  classNameBindings: ['labelValidationClass'],
 
   enforceMinimalOptionsAmount: observer('options', 'isMakeAPoll', function() {
     if (this.get('options.length') < 2) {
@@ -97,11 +31,4 @@ export default Component.extend({
   }).on('init'),
 
   store: service('store'),
-
-  didInsertElement() {
-    // childViews is not observeable by default. Need to notify about a change manually.
-    // Lucky enough we know that child views will only be changed on init and if times are added / removed.
-    // Use a custom variable to avoid any complications with framework.
-    this.notifyPropertyChange('_childViews');
-  }
 });

--- a/app/templates/components/create-options-datetime.hbs
+++ b/app/templates/components/create-options-datetime.hbs
@@ -41,7 +41,7 @@
           as |el|
           }}
             <div class="input-group">
-              {{bs-form/element/control/input
+              {{el.control
                 autofocus=(unless index true false)
                 id=el.id
                 placeholder="00:00"

--- a/app/templates/components/create-options-text.hbs
+++ b/app/templates/components/create-options-text.hbs
@@ -8,7 +8,7 @@
   as |el|
   }}
     <div class="input-group">
-      {{bs-form/element/control/input
+      {{el.control
         autofocus=(unless index true false)
         id=el.id
         value=el.value

--- a/tests/integration/components/create-options-datetime-test.js
+++ b/tests/integration/components/create-options-datetime-test.js
@@ -316,15 +316,13 @@ module('Integration | Component | create options datetime', function(hooks) {
     this.set('options', poll.options);
 
     await render(hbs`{{create-options-datetime dates=options}}`);
-    assert.ok(
-      findAll('.has-error').length === 0 && findAll('.has-success').length === 0,
-      'does not show a validation error before user interaction'
-    );
+    assert.dom('.form-group .is-invalid').doesNotExist('does not show validation errors before user interaction');
+    assert.dom('.form-group .is-valid').doesNotExist('does not show validation success before user interaction');
 
     await fillIn('[data-test-day="2015-01-01"] .form-group input', '10:');
     await blur('[data-test-day="2015-01-01"] .form-group input');
     assert.ok(
-      find('[data-test-day="2015-01-01"] .form-group').classList.contains('has-error') ||
+      find('[data-test-day="2015-01-01"] .form-group input').classList.contains('is-invalid') ||
       // browsers with input type time support prevent non time input
       find('[data-test-day="2015-01-01"] .form-group input').value === '',
       'shows error after invalid input or prevents invalid input'
@@ -336,22 +334,11 @@ module('Integration | Component | create options datetime', function(hooks) {
     await fillIn(findAll('[data-test-day="2015-01-01"]')[1].querySelector('input'), '10:00');
     await fillIn('[data-test-day="2015-02-02"] .form-group input', '10:00');
     await triggerEvent('form', 'submit');
-    assert.dom(findAll('[data-test-day="2015-01-01"]')[0].querySelector('.form-group')).hasClass('has-success',
-      'first time shows validation success'
-    );
-    assert.dom(findAll('[data-test-day="2015-01-01"]')[1].querySelector('.form-group')).hasClass('has-error',
-      'same time for same day shows validation error'
-    );
-    assert.dom('[data-test-day="2015-02-02"] .form-group').hasClass('has-success',
-      'same time for different day shows validation success'
-    );
-
-    // label reflects validation state for all times of this day
-    assert.dom(find('[data-test-day="2015-01-01"]')).hasClass('label-has-error',
-      'label reflects validation state for all times (error)'
-    );
-    assert.dom('[data-test-day="2015-02-02"]').hasClass('label-has-success',
-      'label reflects validation state for all times (success)'
-    );
+    assert.dom(findAll('[data-test-day="2015-01-01"]')[0].querySelector('.form-group input'))
+      .hasClass('is-valid', 'first time shows validation success');
+    assert.dom(findAll('[data-test-day="2015-01-01"]')[1].querySelector('.form-group input'))
+      .hasClass('is-invalid', 'same time for same day shows validation error');
+    assert.dom('[data-test-day="2015-02-02"] .form-group input')
+      .hasClass('is-valid', 'same time for different day shows validation success');
   });
 });

--- a/tests/integration/components/create-options-test.js
+++ b/tests/integration/components/create-options-test.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll, blur, fillIn, focus } from '@ember/test-helpers';
+import { render, findAll, blur, fillIn, focus } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import hasComponent from 'croodle/tests/helpers/201-created/raw/has-component';
 
@@ -65,35 +65,23 @@ module('Integration | Component | create options', function(hooks) {
       hbs`{{create-options options=options isDateTime=isDateTime isFindADate=isFindADate isMakeAPoll=isMakeAPoll}}`
     );
 
-    assert.ok(
-      findAll('input').length === 2,
-      'assumptions are correct'
-    );
+    assert.dom('.form-group').exists({ count: 2 }, 'assumption: renders two form groups');
 
-    await fillIn(findAll('input')[0], 'foo');
-    await blur(findAll('input')[0]);
-    await fillIn(findAll('input')[1], 'foo');
-    await blur(findAll('input')[1]);
-    assert.ok(
-      findAll('.form-group')[1].classList.contains('has-error'),
-      'second input field has validation error'
-    );
-    assert.ok(
-      findAll('.form-group')[1].querySelector('.help-block'),
-      'validation error is shown'
-    );
+    await fillIn('.form-group:nth-child(1) input', 'foo');
+    await blur('.form-group:nth-child(1) input');
+    await fillIn('.form-group:nth-child(2) input', 'foo');
+    await blur('.form-group:nth-child(2) input');
+    assert.dom('.form-group:nth-child(2) input')
+      .hasClass('is-invalid', 'second input field has validation error');
+    assert.dom('.form-group:nth-child(2) .invalid-feedback')
+      .exists('validation error is shown');
 
     await fillIn(findAll('input')[0], 'bar');
     await blur(findAll('input')[0]);
-    assert.ok(
-      findAll('.form-group .help-block').length === 0,
-      'there is no validation error anymore after a unique value is entered'
-    );
-
-    assert.ok(
-      findAll('.form-group.has-error').length === 0,
-      'has-error classes are removed'
-    );
+    assert.dom('.form-group .invalid-feedback')
+      .doesNotExist('there is no validation error anymore after a unique value is entered');
+    assert.dom('.form-group .is-invalid')
+      .doesNotExist('.is-invalid classes are removed');
   });
 
   test('shows validation errors if option is empty (makeAPoll)', async function(assert) {
@@ -127,70 +115,14 @@ module('Integration | Component | create options', function(hooks) {
     await blur(findAll('input')[0]);
     await focus(findAll('input')[1]);
     await blur(findAll('input')[1]);
-    assert.equal(
-      findAll('.form-group.has-error').length, 2
-    );
+    assert.dom('.form-group .invalid-feedback').exists({ count: 2 });
 
     await fillIn(findAll('input')[0], 'foo');
     await blur(findAll('input')[0]);
-    assert.equal(
-      findAll('.form-group.has-error').length, 1
-    );
+    assert.dom('.form-group .invalid-feedback').exists({ count: 1 });
 
     await fillIn(findAll('input')[1], 'bar');
     await blur(findAll('input')[1]);
-    assert.equal(
-      findAll('.form-group.has-error').length, 0
-    );
-  });
-
-  test('label reflects validation state of all inputs (makeAPoll)', async function(assert) {
-    this.set('isDateTime', false);
-    this.set('isFindADate', false);
-    this.set('isMakeAPoll', true);
-
-    // validation is based on validation of every option fragment
-    // which validates according to poll model it belongs to
-    // therefore each option needs to be pushed to poll model to have it as
-    // it's owner
-    let poll;
-    run(() => {
-      poll = this.store.createRecord('poll', {
-        isFindADate: this.get('isFindADate'),
-        isDateTime: this.get('isDateTime'),
-        isMakeAPoll: this.get('isMakeAPoll')
-      });
-    });
-    this.set('options', poll.get('options'));
-
-    await render(
-      hbs`{{create-options options=options isDateTime=isDateTime isFindADate=isFindADate isMakeAPoll=isMakeAPoll}}`
-    );
-
-    assert.ok(
-     find('form').firstElementChild.classList.contains('label-has-no-validation'),
-      'does not show validation state if there wasn\'t any user interaction yet'
-    );
-
-    await focus(findAll('input')[0]);
-    await blur(findAll('input')[0]);
-    assert.ok(
-     find('form').firstElementChild.classList.contains('label-has-error'),
-      'shows as having error if atleast on field has an error'
-    );
-
-    await fillIn(findAll('input')[0], 'foo');
-    await blur(findAll('input')[0]);
-    assert.ok(
-     find('form').firstElementChild.classList.contains('label-has-no-validation'),
-      'does not show validation state if no field has error but not all fields are showing error yet'
-    );
-
-    await fillIn(findAll('input')[1], 'bar');
-    await blur(findAll('input')[1]);
-    assert.ok(
-     find('form').firstElementChild.classList.contains('label-has-success'),
-      'shows as having success if all fields are showing success'
-    );
+    assert.dom('.form-group .invalid-feedback').doesNotExist();
   });
 });

--- a/tests/pages/create/options.js
+++ b/tests/pages/create/options.js
@@ -43,7 +43,7 @@ export default create(assign({}, defaultsForCreate, {
     item: {
       add: clickable('button.add'),
       delete: clickable('button.delete'),
-      hasError: hasClass('has-error'),
+      hasError: hasClass('is-invalid', 'input'),
       title: fillable('input')
     }
   }),


### PR DESCRIPTION
All tests should pass now. The issue wasn't related to your changes but to using a very outdated pattern to refer to the control. It hasn't used the yielded one (`{{el.control}}`) but the private base class of Ember Bootstrap (`{{bs-form/element/control/input}}`). This was working for Bootstrap 3 as the validation class is not on the control but not for Bootstrap 4, which has validation state on control element. Everything beside that little change is only updating CSS classes to reflect the changes between Bootstrap 3 and 4, applying better coding standards and deleting stale code.